### PR TITLE
Fix: Add postgres_connection.json to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,14 @@ COPY --from=builder /usr/local/bin /usr/local/bin
 COPY src/ ./src/
 COPY requirements.txt .
 
+# Create directories for database configuration
+RUN mkdir -p tools/coursera_db_manager/config temp
+
+# Copy database configuration
+COPY tools/coursera_db_manager/config/postgres_connection.json ./tools/coursera_db_manager/config/
+# Also copy to temp location as fallback
+COPY tools/coursera_db_manager/config/postgres_connection.json ./temp/
+
 # Create non-root user for security
 RUN groupadd -r appuser && useradd -r -g appuser appuser
 RUN chown -R appuser:appuser /app


### PR DESCRIPTION
## Summary
- 修復 Course Availability 功能返回全 0 的問題
- 將 postgres_connection.json 配置檔案加入 Docker 映像
- 確保資料庫連接可正常初始化

## Root Cause
Application Insights 診斷顯示錯誤：
```
FileNotFoundError: [Errno 2] No such file or directory: 'tools/coursera_db_manager/config/postgres_connection.json'
```

## Solution
- 在 Dockerfile 中創建必要目錄結構
- 複製 postgres_connection.json 到兩個預期位置
- 確保檔案權限正確設置

## Test Plan
- [x] 本地測試 Dockerfile 建立
- [ ] GitHub Actions CI/CD 自動建立映像
- [ ] 部署到 Azure Container Apps
- [ ] 驗證 Course Availability 返回正確課程數量

🤖 Generated with [Claude Code](https://claude.ai/code)